### PR TITLE
Fix xcaddy plugin path for build

### DIFF
--- a/packages/caddy/README.md
+++ b/packages/caddy/README.md
@@ -15,7 +15,7 @@ To use this module during development, you need to build Caddy with this module 
 
 ```bash
 # From the project root directory
-xcaddy build --with github.com/techsavvyash/veil/packages/caddy=./packages/caddy
+xcaddy build --with github.com/try-veil/veil/packages/caddy=./packages/caddy
 ```
 
 This tells xcaddy to use the local code in `./packages/caddy` instead of fetching from GitHub.
@@ -23,7 +23,7 @@ This tells xcaddy to use the local code in `./packages/caddy` instead of fetchin
 Once the module is published, you can use:
 
 ```bash
-xcaddy build --with github.com/techsavvyash/veil/packages/caddy
+xcaddy build --with github.com/try-veil/veil/packages/caddy
 ```
 
 ## Configuration
@@ -67,7 +67,7 @@ Here's a complete example of how to use Veil:
 1. Build Caddy with the Veil module:
 
 ```bash
-xcaddy build --with github.com/techsavvyash/veil/packages/caddy
+xcaddy build --with github.com/try-veil/veil/packages/caddy
 ```
 
 2. Create a Caddyfile:
@@ -105,7 +105,7 @@ curl -H "X-Subscription-Key: premium" http://localhost:2019/api/v1/products
 First, build Caddy with the Veil module from the project root:
 
 ```bash
-xcaddy build --with github.com/techsavvyash/veil/packages/caddy=./packages/caddy
+xcaddy build --with github.com/try-veil/veil/packages/caddy=./packages/caddy
 ```
 
 This will create a `caddy` binary in your current directory.


### PR DESCRIPTION
### Description
This PR updates the documentation (or build instructions) to correctly reference the plugin path when building Caddy with ```xcaddy```

Replaced:
```
xcaddy build --with github.com/techsavvyash/veil/packages/caddy
```
With:
```
xcaddy build --with github.com/try-veil/veil/packages/caddy
```