### PR TITLE
Combined launch

### DIFF
--- a/packages/platform/api/docs.json
+++ b/packages/platform/api/docs.json
@@ -5095,6 +5095,32 @@
                 }
               }
             }
+          },
+          "query_params": {
+            "type": "object",
+            "description": "Query parameters",
+            "example": {
+              "city": "London",
+              "units": "metric",
+              "appid": "your_api_key"
+            }
+          },
+          "body": {
+            "type": "object",
+            "description": "Request body configuration",
+            "example": {
+              "type": "json",
+              "schema": {
+                "properties": {
+                  "temperature": {
+                    "type": "number"
+                  },
+                  "humidity": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
           }
         },
         "required": [
@@ -5111,7 +5137,9 @@
           "updated_at",
           "required_subscription",
           "required_headers",
-          "parameters"
+          "parameters",
+          "query_params",
+          "body"
         ]
       },
       "MarketplaceCategoryDto": {

--- a/packages/platform/api/src/services/marketplace/dto/marketplace.dto.ts
+++ b/packages/platform/api/src/services/marketplace/dto/marketplace.dto.ts
@@ -237,6 +237,32 @@ export class MarketplaceApiDetailsDto extends MarketplaceApiDto {
     type: string;
     required: boolean;
   }>;
+
+  @ApiProperty({
+    description: 'Query parameters',
+    type: 'object',
+    example: {
+      city: 'London',
+      units: 'metric',
+      appid: 'your_api_key'
+    },
+  })
+  query_params?: Record<string, any>;
+
+  @ApiProperty({
+    description: 'Request body configuration',
+    type: 'object',
+    example: {
+      type: 'json',
+      schema: {
+        properties: {
+          temperature: { type: 'number' },
+          humidity: { type: 'number' }
+        }
+      }
+    },
+  })
+  body?: Record<string, any>;
 }
 
 export class MarketplaceCategoryDto {

--- a/packages/platform/api/src/services/marketplace/marketplace.service.ts
+++ b/packages/platform/api/src/services/marketplace/marketplace.service.ts
@@ -298,12 +298,18 @@ export class MarketplaceService {
     // Extract parameters from specification if available
     const parameters = (api.specification as any)?.parameters || [];
 
+    // Extract query_params and body from the API data
+    const queryParams = api.queryParams ? (api.queryParams as any) : undefined;
+    const bodyConfig = api.bodyConfig ? (api.bodyConfig as any) : undefined;
+
     return {
       ...baseApi,
       required_subscription:
         (api.specification as any)?.required_subscription || 'basic',
       required_headers: headers,
       parameters: parameters,
+      query_params: queryParams,
+      body: bodyConfig,
     };
   }
 

--- a/packages/platform/web/apps/complete-application/src/app/api/auth/login/route.ts
+++ b/packages/platform/web/apps/complete-application/src/app/api/auth/login/route.ts
@@ -37,7 +37,12 @@ export async function POST(request: Request) {
       }),
     });
 
-    const data = await response.json();
+    let data;
+    try {
+      data = await response.json();
+    } catch (jsonError) {
+      data = {};
+    }
 
     if (response.ok) {
       const accessToken = data.token || data.jwt;
@@ -55,10 +60,24 @@ export async function POST(request: Request) {
         refreshToken
       });
     } else {
+      let errorMessage = "Login failed";
+      
+      if (response.status === 404) {
+        errorMessage = "Invalid email or password";
+      } else if (response.status === 401) {
+        errorMessage = "Invalid email or password";
+      } else if (response.status === 400) {
+        errorMessage = "Please check your email and password";
+      } else if (data.error_description) {
+        errorMessage = data.error_description;
+      } else if (data.error) {
+        errorMessage = data.error;
+      }
+      
       return NextResponse.json(
         {
-          error: data.error,
-          error_description: data.error_description,
+          error: errorMessage,
+          error_description: errorMessage,
         },
         { status: response.status }
       );

--- a/packages/platform/web/apps/complete-application/src/app/api/auth/signup/route.ts
+++ b/packages/platform/web/apps/complete-application/src/app/api/auth/signup/route.ts
@@ -55,11 +55,18 @@ export async function POST(req: Request) {
 
     if (!registerResponse.ok) {
       const fieldError = registerData?.fieldErrors;
-      const firstErrorMessage =
+      let firstErrorMessage =
+        fieldError?.["user.password"]?.[0]?.message ||
         fieldError?.["user.email"]?.[0]?.message ||
         fieldError?.["userId"]?.[0]?.message ||
         registerData?.error ||
         "Registration failed";
+      
+      // Clean up field names in error messages
+      firstErrorMessage = firstErrorMessage.replace(/\[user\.password\]/g, 'password');
+      firstErrorMessage = firstErrorMessage.replace(/\[user\.email\]/g, 'email');
+      firstErrorMessage = firstErrorMessage.replace(/\s+property/g, '');
+      
       console.error("Registration error:", firstErrorMessage);
       return NextResponse.json({ error: firstErrorMessage, error_description: firstErrorMessage }, { status: registerResponse.status });
     }

--- a/packages/platform/web/apps/complete-application/src/app/signup/page.tsx
+++ b/packages/platform/web/apps/complete-application/src/app/signup/page.tsx
@@ -17,13 +17,13 @@ import { Button } from "@/components/ui/button";
 export default function SignupPage() {
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
-  const [role, setRole] = useState<string>("");
+  const consumerRoleId = process.env.NEXT_PUBLIC_ROLE_CONSUMER_ID;
+  const providerRoleId = process.env.NEXT_PUBLIC_ROLE_PROVIDER_ID;
+  const [role, setRole] = useState<string>(providerRoleId ?? "provider");
   const [error, setError] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
   const router = useRouter();
   const { login, isAuthenticated } = useAuth();
-  const consumerRoleId = process.env.NEXT_PUBLIC_ROLE_CONSUMER_ID;
-  const providerRoleId = process.env.NEXT_PUBLIC_ROLE_PROVIDER_ID;
   const githubIdentityProviderId =
     process.env.NEXT_PUBLIC_GITHUB_IDENTITY_PROVIDER_ID;
   const googleIdentityProviderId =
@@ -162,7 +162,7 @@ export default function SignupPage() {
                   className="w-full px-3 py-2 border rounded-md"
                 />
               </div>
-              <div>
+              {/* <div>
                 <Select
                   value={role}
                   onValueChange={(value) => {
@@ -182,7 +182,7 @@ export default function SignupPage() {
                     </SelectItem>
                   </SelectContent>
                 </Select>
-              </div>
+              </div> */}
               {error && <p className="text-sm text-red-500">{error}</p>}
               <button
                 type="submit"

--- a/packages/platform/web/apps/complete-application/src/features/consumer/endpoint-viewer.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/consumer/endpoint-viewer.tsx
@@ -166,6 +166,16 @@ export default function EndpointViewer({
     }));
   };
 
+  const handleHeaderValueChange = (headerName: string, value: string) => {
+    setHeaderValues(prev => ({
+      ...prev,
+      [headerName]: {
+        ...prev[headerName],
+        value: value
+      }
+    }));
+  };
+
   const handleCopyUrl = async () => {
     const url = getFullUrl();
     await navigator.clipboard.writeText(url);
@@ -429,6 +439,27 @@ export default function EndpointViewer({
                     value={`test-key-${apiDetails?.api_id}`}
                   />
                 </div>
+                
+                {/* Dynamic Required Headers */}
+                {apiDetails?.required_headers && apiDetails.required_headers.length > 0 && (
+                  <div className="space-y-4 mt-6">
+                    <div className="border-t pt-4">
+                      <p className="font-medium mb-4">Required Headers</p>
+                      {apiDetails.required_headers.map((header) => (
+                        <div key={header.name} className="space-y-2 mb-4">
+                          <Label htmlFor={header.name}>{header.name}</Label>
+                          <Input
+                            id={header.name}
+                            placeholder={header.is_variable ? `Enter value for ${header.name}` : header.value}
+                            value={headerValues[header.name]?.value || ""}
+                            onChange={(e) => handleHeaderValueChange(header.name, e.target.value)}
+                            disabled={!header.is_variable}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/index.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/index.tsx
@@ -347,6 +347,12 @@ export default function Request({
 
     setIsTestLoading(true);
 
+    const queryString = queryParams
+  .map(({ key, value }) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+  .join('&');
+
+  const queryPath = path+ `?${queryString}`;
+
     try {
       const payload = {
         api_id:
@@ -355,7 +361,7 @@ export default function Request({
             : crypto.randomUUID(),
         project_id: project_id,
         name,
-        path,
+        path: queryPath,
         target_url: targetUrl,
         method,
         version,

--- a/packages/platform/web/apps/complete-application/src/features/projects/request/index.tsx
+++ b/packages/platform/web/apps/complete-application/src/features/projects/request/index.tsx
@@ -11,6 +11,14 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Headers } from "./components/headers";
 import { Query } from "./components/query";
 import Body from "./components/body";
@@ -23,7 +31,7 @@ import { useRouter } from "next/navigation";
 import { z } from "zod";
 import crypto from "crypto";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 
 const requestFormSchema = z.object({
   name: z.string().min(1, { message: "Endpoint name is required" }),
@@ -33,15 +41,17 @@ const requestFormSchema = z.object({
   //   .startsWith("/", { message: "Path must start with /" }),
   documentation_url: z.union([
     z.string().url({ message: "Please enter a valid URL" }),
-    z.string().length(0)
+    z.string().length(0),
   ]),
   method: z.string(),
-  headers: z.array(
-    z.object({
-      name: z.string(),
-      value: z.string()
-    })
-  ).optional()
+  headers: z
+    .array(
+      z.object({
+        name: z.string(),
+        value: z.string(),
+      })
+    )
+    .optional(),
 });
 
 type RequestFormData = z.infer<typeof requestFormSchema>;
@@ -132,8 +142,12 @@ export default function Request({
   const [path, setPath] = useState("");
   const [storedUuid, setStoredUuid] = useState("");
   const [method, setMethod] = useState<string>(initialData?.method || "GET");
-  const [description, setDescription] = useState(initialData?.description || "");
-  const [documentationUrl, setDocumentationUrl] = useState(initialData?.documentation_url || "");
+  const [description, setDescription] = useState(
+    initialData?.description || ""
+  );
+  const [documentationUrl, setDocumentationUrl] = useState(
+    initialData?.documentation_url || ""
+  );
   const [version, setVersion] = useState(initialData?.version || "1.0.0");
   const [headers, setHeaders] = useState<{ name: string; value: string }[]>(
     initialData?.required_headers?.map((h) => ({
@@ -141,7 +155,9 @@ export default function Request({
       value: h.value,
     })) || []
   );
-  const [queryParams, setQueryParams] = useState<{ key: string; value: string }[]>([]);
+  const [queryParams, setQueryParams] = useState<
+    { key: string; value: string }[]
+  >([]);
   const [bodyData, setBodyData] = useState<{
     type: string;
     content: string;
@@ -155,6 +171,8 @@ export default function Request({
   });
   const [isTestLoading, setIsTestLoading] = useState(false);
   const [isDeleteLoading, setIsDeleteLoading] = useState(false);
+  const [showMethodChangeDialog, setShowMethodChangeDialog] = useState(false);
+  const [pendingMethod, setPendingMethod] = useState<string>("");
   const { selectedProject } = useProject();
 
   useEffect(() => {
@@ -172,31 +190,74 @@ export default function Request({
         })) || []
       );
       setQueryParams(initialData.query_params || []);
-      setBodyData(initialData.body || {
-        type: "json",
-        content: "",
-        form_data: [],
-        json_data: null,
-      });
+      setBodyData(
+        initialData.body || {
+          type: "json",
+          content: "",
+          form_data: [],
+          json_data: null,
+        }
+      );
     }
   }, [initialData]);
 
   useEffect(() => {
     if (initialData?.path) {
-      const pathParts = initialData.path.split('/');
+      const pathParts = initialData.path.split("/");
       if (pathParts.length > 1) {
         setStoredUuid(pathParts[0]);
-        setPath('/' + pathParts.slice(1).join('/'));
+        setPath("/" + pathParts.slice(1).join("/"));
       } else {
         setPath(initialData.path);
       }
     }
   }, [initialData?.path]);
 
+  const handleMethodChange = (newMethod: string) => {
+    const currentMethodHasBody = ["post", "put", "patch"].includes(method.toLowerCase());
+    const newMethodIsGet = newMethod.toLowerCase() === "get";
+    
+    // Check if we're changing from a method that supports body to GET
+    if (currentMethodHasBody && newMethodIsGet) {
+      // Check if there's actual body content
+      const hasBodyContent = 
+        bodyData.content.trim() !== "" ||
+        (bodyData.form_data && bodyData.form_data.length > 0) ||
+        bodyData.json_data !== null;
+      
+      if (hasBodyContent) {
+        setPendingMethod(newMethod);
+        setShowMethodChangeDialog(true);
+        return;
+      }
+    }
+    
+    // If no confirmation needed, just change the method
+    setMethod(newMethod);
+  };
+
+  const handleConfirmMethodChange = () => {
+    setMethod(pendingMethod);
+    // Clear body data when changing to GET
+    setBodyData({
+      type: "text",
+      content: "",
+      form_data: [],
+      json_data: null,
+    });
+    setShowMethodChangeDialog(false);
+    setPendingMethod("");
+  };
+
+  const handleCancelMethodChange = () => {
+    setShowMethodChangeDialog(false);
+    setPendingMethod("");
+  };
+
   const handlePathChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     let newPath = e.target.value;
-    if (!newPath.startsWith('/')) {
-      newPath = '/' + newPath;
+    if (!newPath.startsWith("/")) {
+      newPath = "/" + newPath;
     }
     setPath(newPath);
   };
@@ -216,9 +277,7 @@ export default function Request({
     newQueries: { id: string; key: string; value: string }[]
   ) => {
     const processedQueries = newQueries
-      .filter(
-        (query) => query.key.trim() !== "" && query.value.trim() !== ""
-      )
+      .filter((query) => query.key.trim() !== "" && query.value.trim() !== "")
       .map(({ key, value }) => ({ key, value }));
     setQueryParams(processedQueries);
   };
@@ -236,9 +295,9 @@ export default function Request({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     const finalPath = initialData?.path ? `${storedUuid}${path}` : path;
-    
+
     const formData = {
       name,
       description,
@@ -252,7 +311,10 @@ export default function Request({
     };
 
     console.log("🚀 Submitting API request with data:", formData);
-    console.log("📝 Request type:", initialData?.path !== "" ? "UPDATE" : "CREATE");
+    console.log(
+      "📝 Request type:",
+      initialData?.path !== "" ? "UPDATE" : "CREATE"
+    );
 
     const result = requestFormSchema.safeParse(formData);
     if (!result.success) {
@@ -265,7 +327,7 @@ export default function Request({
       return;
     }
     setErrors({});
-    
+
     console.log("✅ Form validation passed, calling onSave handler");
     if (onSave) {
       onSave(formData as RequestData);
@@ -287,14 +349,17 @@ export default function Request({
 
     try {
       const payload = {
-        api_id: initialData?.api_id && initialData.api_id !== "" ? initialData.api_id : crypto.randomUUID(),
+        api_id:
+          initialData?.api_id && initialData.api_id !== ""
+            ? initialData.api_id
+            : crypto.randomUUID(),
         project_id: project_id,
         name,
         path,
         target_url: targetUrl,
         method,
         version,
-        required_headers: headers.map(h => ({
+        required_headers: headers.map((h) => ({
           name: h.name,
           value: h.value,
           is_variable: false,
@@ -307,8 +372,8 @@ export default function Request({
       console.log("🌐 Making request to:", `${API_BASE_URL}/onboard/test`);
 
       if (onTest) {
-      await onTest(payload as TestRequestData);
-    }
+        await onTest(payload as TestRequestData);
+      }
       console.log("✅ Test API successful");
     } catch (error) {
       console.log("❌ Test API error:", error);
@@ -324,7 +389,7 @@ export default function Request({
         console.log("❌ Delete API failed - missing required data:", {
           projectId: selectedProject?.id,
           apiId: initialData?.api_id,
-          hasAccessToken: !!accessToken
+          hasAccessToken: !!accessToken,
         });
         toast({
           title: "Error",
@@ -333,24 +398,24 @@ export default function Request({
         });
         return;
       }
-      
+
       console.log("🗑️ Deleting API:", {
         projectId: selectedProject.id,
-        apiId: initialData.api_id
+        apiId: initialData.api_id,
       });
-      
+
       toast({
         title: "Deleting API...",
         description: "Please wait while we process your request",
         variant: "default",
       });
-      
+
       await deleteAPI(
         selectedProject.id.toString(),
         initialData.api_id.toString(),
         accessToken
       );
-      
+
       console.log("✅ API deleted successfully");
       await refreshProject();
       toast({
@@ -374,19 +439,16 @@ export default function Request({
     <div className="flex flex-col h-full">
       <div className="flex-none p-4 border-b">
         <div className="flex flex-col sm:flex-row gap-4 items-center">
-          <Select value={method} onValueChange={setMethod}>
+          <Select value={method} onValueChange={handleMethodChange}>
             <SelectTrigger className="w-full sm:w-[120px]">
               <SelectValue>{options.get(method)}</SelectValue>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="get">GET</SelectItem>
-              <SelectItem value="head">HEAD</SelectItem>
               <SelectItem value="post">POST</SelectItem>
               <SelectItem value="put">PUT</SelectItem>
               <SelectItem value="delete">DELETE</SelectItem>
               <SelectItem value="patch">PATCH</SelectItem>
-              <SelectItem value="options">OPTIONS</SelectItem>
-              <SelectItem value="trace">TRACE</SelectItem>
             </SelectContent>
           </Select>
           <Input
@@ -395,10 +457,10 @@ export default function Request({
             value={path}
             onChange={handlePathChange}
           />
-           <div className="flex gap-2">
+          <div className="flex gap-2">
             <Button
               onClick={handleTest}
-              disabled={isTestLoading || initialData?.path == "" }
+              disabled={isTestLoading || initialData?.path == ""}
               variant="secondary"
               size="sm"
               className="min-w-[80px]"
@@ -455,9 +517,10 @@ export default function Request({
               <></>
             )}
           </div>
-          
         </div>
-        {errors?.path && <p className="text-sm text-red-500 mt-1 ml-1">{errors.path}</p>}
+        {errors?.path && (
+          <p className="text-sm text-red-500 mt-1 ml-1">{errors.path}</p>
+        )}
       </div>
 
       <div className="flex-1 flex flex-col min-h-0">
@@ -466,12 +529,8 @@ export default function Request({
             <TabsList className="w-full justify-start">
               <TabsTrigger value="overview">Description</TabsTrigger>
               <TabsTrigger value="headers">Headers</TabsTrigger>
-              <TabsTrigger value="query">
-                Query
-              </TabsTrigger>
-              <TabsTrigger value="body">
-                Body
-              </TabsTrigger>
+              <TabsTrigger value="query">Query</TabsTrigger>
+              <TabsTrigger value="body">Body</TabsTrigger>
             </TabsList>
           </div>
 
@@ -486,7 +545,9 @@ export default function Request({
                       value={name}
                       onChange={(e) => setName(e.target.value)}
                     />
-                    {errors?.name && <p className="text-sm text-red-500">{errors.name}</p>}
+                    {errors?.name && (
+                      <p className="text-sm text-red-500">{errors.name}</p>
+                    )}
                   </div>
                   <div className="space-y-2">
                     <Label>Description</Label>
@@ -512,36 +573,68 @@ export default function Request({
                       onChange={(e) => setDocumentationUrl(e.target.value)}
                     />
                     {errors?.documentation_url && (
-    <p className="text-sm text-red-500">{errors.documentation_url}</p>
-  )}
+                      <p className="text-sm text-red-500">
+                        {errors.documentation_url}
+                      </p>
+                    )}
                   </div>
                 </div>
               </TabsContent>
 
               <TabsContent value="headers" className="mt-0 h-full">
-                <Headers 
-                  onHeadersChange={handleHeadersChange} 
+                <Headers
+                  onHeadersChange={handleHeadersChange}
                   initialHeaders={headers}
                 />
               </TabsContent>
 
               <TabsContent value="query" className="mt-0 h-full">
-                <Query 
-                  onQueryChange={handleQueryChange} 
+                <Query
+                  onQueryChange={handleQueryChange}
                   initialQueries={queryParams}
                 />
               </TabsContent>
 
               <TabsContent value="body" className="mt-0 h-full">
-                <Body 
-                  onBodyChange={handleBodyChange} 
-                  initialBodyData={bodyData}
-                />
+                {method === "get" ? (
+                  <div className="text-muted-foreground py-4 p-1 text-center">
+                    Body is not applicable for GET requests.
+                  </div>
+                ) : (
+                  <Body
+                    onBodyChange={handleBodyChange}
+                    initialBodyData={bodyData}
+                  />
+                )}
               </TabsContent>
             </div>
           </div>
         </Tabs>
       </div>
+
+      <Dialog
+        open={showMethodChangeDialog}
+        onOpenChange={setShowMethodChangeDialog}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Method Change</DialogTitle>
+          </DialogHeader>
+          <DialogDescription>
+            Changing the request method to GET will remove any existing body
+            content. Do you want to continue?
+          </DialogDescription>
+          <DialogFooter>
+            <Button
+              variant="secondary"
+              onClick={handleCancelMethodChange}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleConfirmMethodChange}>Continue</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
- Restrict user to enter Body for a GET Request + While changing from POST/PATCH to a GET request show alert of payload being deleted
- include query params while testing in provider playground
- update /marketplace/apis/{apiId} endpoint to return query_params and body
- add required headers logic in consumer playground
- add body logic in consumer playground
- fix tabs state switching
- restrict body for get method
- remove consumer role from signup and restrict as provider
- fix signup error message for short passwords
- fix login error messages for incorrect passwords or emails