### PR TITLE
refactor: move CORS origins to environment variable

### DIFF
--- a/packages/platform-api/.env.example
+++ b/packages/platform-api/.env.example
@@ -9,6 +9,9 @@ JWT_EXPIRES_IN=7d
 PORT=3000
 NODE_ENV=development
 
+# CORS Configuration
+CORS_ORIGINS=http://localhost:3001,http://localhost:3000
+
 # Veil API Configuration
 VEIL_API_BASE_URL=http://localhost:2020
 VEIL_API_TIMEOUT=10000

--- a/packages/platform-api/src/config.ts
+++ b/packages/platform-api/src/config.ts
@@ -13,7 +13,7 @@ export const config = {
   },
   
   cors: {
-    origin: 'http://localhost:3001',
+    origins: process.env.CORS_ORIGINS?.split(',') || ['http://localhost:3001', 'http://localhost:3000'],
     credentials: true,
   },
   

--- a/packages/platform-api/src/index.ts
+++ b/packages/platform-api/src/index.ts
@@ -31,7 +31,7 @@ import { natsClient } from "./services/nats-client";
 
 const app = new Elysia()
   // Add middleware
-  .use(customCors(['http://localhost:3001', 'http://localhost:3000']))
+  .use(customCors(config.cors.origins))
   .use(swagger({
     documentation: {
       info: {
@@ -161,7 +161,7 @@ async function initializeServices() {
 
 console.log(`📊 Environment: ${config.nodeEnv}`);
 console.log(`🔗 Database URL: ${config.database.url.replace(/:[^:]*@/, ':****@')}`);
-console.log(`🔒 CORS Origin: http://localhost:3001,http://localhost:3000`);
+console.log(`🔒 CORS Origins: ${config.cors.origins.join(', ')}`);
 
 // Graceful shutdown
 process.on('SIGINT', async () => {


### PR DESCRIPTION
Move hardcoded CORS origins to CORS_ORIGINS environment variable for better configuration flexibility across environments.

Changes:
- Add CORS_ORIGINS env var support in config.ts (comma-separated)
- Update index.ts to use config.cors.origins instead of hardcoded array
- Update console log to display configured origins dynamically
- Add CORS_ORIGINS to .env.example with default localhost origins

🤖 Generated with [Claude Code](https://claude.com/claude-code)